### PR TITLE
set StrictHostKeyChecking to no to avoid prompting

### DIFF
--- a/karmada-CLI-installtion-example/foreground.sh
+++ b/karmada-CLI-installtion-example/foreground.sh
@@ -28,9 +28,10 @@ function createCluster() {
     KUBECONFIG=~/config-member1:~/config-member2 kubectl config view --merge --flatten >> ${KUBECONFIG_PATH}/config
     # modify ip
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member1
-    scp config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
+    # set StrictHostKeyChecking to no to avoid prompting, the same below
+    scp -o StrictHostKeyChecking=no config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member2
-    scp config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
+    scp -o StrictHostKeyChecking=no config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
 EOF
 }
 
@@ -47,7 +48,7 @@ EOF
 
 function cluster2Config() {
     touch cluster2.yaml
-    cat << EOF > cluster2.yaml 
+    cat << EOF > cluster2.yaml
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
     networking:
@@ -57,10 +58,12 @@ EOF
 }
 
 function copyConfigFilesToNode() {
-    scp installKind.sh root@${member_cluster_ip}:~
-    scp createCluster.sh root@${member_cluster_ip}:~
-    scp cluster1.yaml root@${member_cluster_ip}:~
-    scp cluster2.yaml root@${member_cluster_ip}:~
+    scp -o StrictHostKeyChecking=no \
+        installKind.sh \
+        createCluster.sh \
+        cluster1.yaml \
+        cluster2.yaml \
+        root@${member_cluster_ip}:~
 }
 
 kubectl delete node node01
@@ -74,9 +77,9 @@ cluster2Config
 copyConfigFilesToNode
 
 # create cluster in node01 machine
-ssh root@${member_cluster_ip} "bash ~/installKind.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/installKind.sh" &
 sleep 10
-ssh root@${member_cluster_ip} "bash ~/createCluster.sh"
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.sh"
 
-# clean screen 
+# clean screen
 clear

--- a/karmada-Failover-example/foreground.sh
+++ b/karmada-Failover-example/foreground.sh
@@ -28,9 +28,10 @@ function createCluster() {
     KUBECONFIG=~/config-member1:~/config-member2 kubectl config view --merge --flatten >> ${KUBECONFIG_PATH}/config
     # modify ip
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member1
-    scp config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
+    # set StrictHostKeyChecking to no to avoid prompting, the same below
+    scp -o StrictHostKeyChecking=no config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member2
-    scp config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
+    scp -o StrictHostKeyChecking=no config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
 EOF
 }
 
@@ -110,12 +111,13 @@ function propagationPolicy() {
 EOF
 }
 
-
 function copyConfigFilesToNode() {
-    scp installKind.sh root@${member_cluster_ip}:~
-    scp createCluster.sh root@${member_cluster_ip}:~
-    scp cluster1.yaml root@${member_cluster_ip}:~
-    scp cluster2.yaml root@${member_cluster_ip}:~
+    scp -o StrictHostKeyChecking=no \
+        installKind.sh \
+        createCluster.sh \
+        cluster1.yaml \
+        cluster2.yaml \
+        root@${member_cluster_ip}:~
 }
 
 kubectl delete node node01
@@ -135,9 +137,9 @@ nginxDeployment
 propagationPolicy
 
 # create cluster in node01 machine
-ssh root@${member_cluster_ip} "bash ~/installKind.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/installKind.sh" &
 sleep 10
-ssh root@${member_cluster_ip} "bash ~/createCluster.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.sh" &
 sleep 90
 
 # install karmadactl

--- a/karmada-HA-workload-example1/foreground.sh
+++ b/karmada-HA-workload-example1/foreground.sh
@@ -28,9 +28,10 @@ function createCluster() {
     KUBECONFIG=~/config-member1:~/config-member2 kubectl config view --merge --flatten >> ${KUBECONFIG_PATH}/config
     # modify ip
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member1
-    scp config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
+    # set StrictHostKeyChecking to no to avoid prompting, the same below
+    scp -o StrictHostKeyChecking=no config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member2
-    scp config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
+    scp -o StrictHostKeyChecking=no config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
 EOF
 }
 
@@ -101,12 +102,13 @@ function propagationPolicy() {
 EOF
 }
 
-
 function copyConfigFilesToNode() {
-    scp installKind.sh root@${member_cluster_ip}:~
-    scp createCluster.sh root@${member_cluster_ip}:~
-    scp cluster1.yaml root@${member_cluster_ip}:~
-    scp cluster2.yaml root@${member_cluster_ip}:~
+    scp -o StrictHostKeyChecking=no \
+        installKind.sh \
+        createCluster.sh \
+        cluster1.yaml \
+        cluster2.yaml \
+        root@${member_cluster_ip}:~
 }
 
 kubectl delete node node01
@@ -126,9 +128,9 @@ nginxDeployment
 propagationPolicy
 
 # create cluster in node01 machine
-ssh root@${member_cluster_ip} "bash ~/installKind.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/installKind.sh" &
 sleep 10
-ssh root@${member_cluster_ip} "bash ~/createCluster.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.sh" &
 sleep 90
 
 # install karmadactl

--- a/karmada-HA-workload-example2/foreground.sh
+++ b/karmada-HA-workload-example2/foreground.sh
@@ -28,9 +28,10 @@ function createCluster() {
     KUBECONFIG=~/config-member1:~/config-member2 kubectl config view --merge --flatten >> ${KUBECONFIG_PATH}/config
     # modify ip
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member1
-    scp config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
+    # set StrictHostKeyChecking to no to avoid prompting, the same below
+    scp -o StrictHostKeyChecking=no config-member1 root@${host_cluster_ip}:$HOME/.kube/config-member1
     sed -i "s/${local_ip}/${member_cluster_ip}/g"  config-member2
-    scp config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
+    scp -o StrictHostKeyChecking=no config-member2 root@${host_cluster_ip}:$HOME/.kube/config-member2
 EOF
 }
 
@@ -110,12 +111,13 @@ function propagationPolicy() {
 EOF
 }
 
-
 function copyConfigFilesToNode() {
-    scp installKind.sh root@${member_cluster_ip}:~
-    scp createCluster.sh root@${member_cluster_ip}:~
-    scp cluster1.yaml root@${member_cluster_ip}:~
-    scp cluster2.yaml root@${member_cluster_ip}:~
+    scp -o StrictHostKeyChecking=no \
+        installKind.sh \
+        createCluster.sh \
+        cluster1.yaml \
+        cluster2.yaml \
+        root@${member_cluster_ip}:~
 }
 
 kubectl delete node node01
@@ -135,9 +137,9 @@ nginxDeployment
 propagationPolicy
 
 # create cluster in node01 machine
-ssh root@${member_cluster_ip} "bash ~/installKind.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/installKind.sh" &
 sleep 10
-ssh root@${member_cluster_ip} "bash ~/createCluster.sh" &
+ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.sh" &
 sleep 90
 
 # install karmadactl


### PR DESCRIPTION
The Killercoda environment provides two hosts with the IP addresses `172.30.1.2` and `172.30.2.2`. During the scenario environment preparation process, SSH/SCP operations between these two hosts are involved.Due to the environment's SSH configuration of `StrictHostKeyChecking=ask`, a key verification prompt will pop up when executing SCP/SSH for the first connection. This causes script blocking and ultimately leads to environment initialization failure.
```bash
The authenticity of host '172.30.2.2 (172.30.2.2)' can't be established.
ED25519 key fingerprint is SHA256:XikjTSvie4xfSHl8CD14UKeq6b3m5zuJAlVVC6JLlao.
This host key is known by the following other names/addresses:
 ~/.ssh/known_hosts:1: [hashed name]
 ~/.ssh/known_hosts:2: [hashed name]
 ~/.ssh/known_hosts:3: [hashed name]
 ~/.ssh/known_hosts:4: [hashed name]
 ~/.ssh/known_hosts:5: [hashed name]
Are you sure you want to continue connecting (yes/no/[fingerprint])?
```
`Solution`: Use `ssh-keyscan` to pre-add the host fingerprints to the `known_hosts` file.

PS: Due to the lack of information about the previous environment and the inability to find the changelog for the backend image `kubernetes-kubeadm-2nodes`, I'm not certain about the exact change that caused this issue.

Test: https://killercoda.com/zhzhuang-zju.