### PR TITLE
Update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Karmada (Kubernetes Armada) is a Kubernetes management system that enables you to run your cloud-native applications across multiple Kubernetes clusters and clouds, with no changes to your applications. By speaking Kubernetes-native APIs and providing advanced scheduling capabilities, Karmada enables truly open, multi-cloud Kubernetes.
 
-So in order to let users try and learn Karmada with an interactive online environment, Karmada provide different scenarios on different platforms.
+So in order to let users try and learn Karmada with an interactive online environment, Karmada provides different scenarios on different platforms.
 
 ## Available platforms
 
-You can enjoy tutorial experience about Karmada with following platforms.
+You can enjoy tutorial experience about Karmada with the following platforms.
 
 ### Killercoda platform
 
@@ -15,7 +15,7 @@ You can enjoy tutorial experience about Karmada with following platforms.
 * Try [Installing Karmada on Kubernetes through the Karmada CLI](https://killercoda.com/karmada/scenario/karmada-CLI-installtion-example).
 * Try [Propagate workload through karmada duplicated mode](https://killercoda.com/karmada/scenario/karmada-HA-workload-example1).
 * Try [Propagate workload through karmada divided mode](https://killercoda.com/karmada/scenario/karmada-HA-workload-example2).
-* Try [Simulate multitype cluster failover through Karmada](https://killercoda.com/karmada/scenario/karmada-Failover-example).
+* Try [Simulate multi-type cluster failover through Karmada](https://killercoda.com/karmada/scenario/karmada-Failover-example).
 
 
 ## Contribution

--- a/karmada-CLI-installtion-example/foreground.sh
+++ b/karmada-CLI-installtion-example/foreground.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 # variable define
-kind_version=v0.17.0
+kind_version=v0.26.0
 host_cluster_ip=172.30.1.2 #host node where Karmada is located
 member_cluster_ip=172.30.2.2
 local_ip=127.0.0.1

--- a/karmada-CLI-installtion-example/index.json
+++ b/karmada-CLI-installtion-example/index.json
@@ -18,7 +18,7 @@
           "verify": "step2/verify.sh"
         },
         {
-          "title": "initialize Karmada",
+          "title": "Initialize Karmada",
           "text": "step3/text.md",
           "verify": "step3/verify.sh"
         },

--- a/karmada-CLI-installtion-example/index.json
+++ b/karmada-CLI-installtion-example/index.json
@@ -18,7 +18,7 @@
           "verify": "step2/verify.sh"
         },
         {
-          "title": "initialize karamda",
+          "title": "initialize Karmada",
           "text": "step3/text.md",
           "verify": "step3/verify.sh"
         },

--- a/karmada-CLI-installtion-example/step3/text.md
+++ b/karmada-CLI-installtion-example/step3/text.md
@@ -1,3 +1,3 @@
-### Initialize karamda
+### Initialize Karmada
 
 RUN `karmadactl init`{{exec}}

--- a/karmada-Failover-example/foreground.sh
+++ b/karmada-Failover-example/foreground.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 # variable define
-kind_version=v0.17.0
+kind_version=v0.26.0
 host_cluster_ip=172.30.1.2 #host node where Karmada is located
 member_cluster_ip=172.30.2.2
 local_ip=127.0.0.1
@@ -74,14 +74,14 @@ function nginxDeployment() {
             app: nginx
         spec:
           containers:
-          - image: nginx
+          - image: nginx:1.27-alpine
             name: nginx
 EOF
 }
 
 function propagationPolicy() {
     cat << EOF > propagationPolicy.yaml
-    apiVersion: policy.karmada.io/v1alpha1
+    apiVersion: policy.karmada.io/v1beta1
     kind: PropagationPolicy
     metadata:
       name: nginx-propagation
@@ -143,7 +143,7 @@ ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.
 sleep 90
 
 # install karmadactl
-curl -s https://raw.githubusercontent.com/karmada-io/karmada/master/hack/install-cli.sh | sudo bash
+curl -s https://raw.githubusercontent.com/karmada-io/karmada/v1.12.0/hack/install-cli.sh | sudo bash
 
 # init karmada, and enable Failover feature gate and eviction feature
 karmadactl init --karmada-controller-manager-extra-args="--feature-gates=Failover=true,--enable-no-execute-taint-eviction=true"

--- a/karmada-Failover-example/step2/text.md
+++ b/karmada-Failover-example/step2/text.md
@@ -2,9 +2,9 @@
 
 display current nginxDeployment.yaml file and propagationPolicy.yaml file
 
-RUN ` cat ~/nginx/nginxDeployment.yaml`{{exec}}
+RUN `cat ~/nginx/nginxDeployment.yaml`{{exec}}
 
-RUN ` cat ~/nginx/propagationPolicy.yaml`{{exec}}
+RUN `cat ~/nginx/propagationPolicy.yaml`{{exec}}
 
 create deployment named nginx
 
@@ -14,7 +14,7 @@ create deployment named nginx
 
 check deployments and pods and their distribution across member clusters:
 - You should see that the deployment is created and pods are running on both member clusters as per the propagation policy.
-- Their distribution should be: kind-member1: 2 pods, kind-member2: 1 pods.
+- Their distribution should be: kind-member1: 2 pods, kind-member2: 1 pod.
 
 RUN `karmadactl --kubeconfig /etc/karmada/karmada-apiserver.config get deployment --operation-scope members`{{exec}}
 

--- a/karmada-HA-workload-example1/finish.md
+++ b/karmada-HA-workload-example1/finish.md
@@ -1,3 +1,3 @@
 **Summary**
 
-In this scenario, we learned how deploy workloads across multiple clusters using PropagationPolicy to duplicate the nginx deployment.
+In this scenario, we learned how to deploy workloads across multiple clusters using PropagationPolicy to duplicate the nginx deployment.

--- a/karmada-HA-workload-example1/foreground.sh
+++ b/karmada-HA-workload-example1/foreground.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 # variable define
-kind_version=v0.17.0
+kind_version=v0.26.0
 host_cluster_ip=172.30.1.2 #host node where Karmada is located
 member_cluster_ip=172.30.2.2
 local_ip=127.0.0.1
@@ -76,14 +76,14 @@ function nginxDeployment() {
             app: nginx
         spec:
           containers:
-          - image: nginx
+          - image: nginx:1.27-alpine
             name: nginx
 EOF
 }
 
 function propagationPolicy() {
     cat << EOF > propagationPolicy.yaml
-    apiVersion: policy.karmada.io/v1alpha1
+    apiVersion: policy.karmada.io/v1beta1
     kind: PropagationPolicy
     metadata:
       name: nginx-propagation  
@@ -134,7 +134,7 @@ ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.
 sleep 90
 
 # install karmadactl
-curl -s https://raw.githubusercontent.com/karmada-io/karmada/master/hack/install-cli.sh | sudo bash
+curl -s https://raw.githubusercontent.com/karmada-io/karmada/v1.12.0/hack/install-cli.sh | sudo bash
 
 # init karmada
 karmadactl init

--- a/karmada-HA-workload-example1/index.json
+++ b/karmada-HA-workload-example1/index.json
@@ -18,7 +18,7 @@
           "verify": "step2/verify.sh"
         },
         {
-          "title": "Create propagationPolicy and deploy deployment",
+          "title": "Create propagationPolicy and deploy workload",
           "text": "step3/text.md",
           "verify": "step3/verify.sh"
         },

--- a/karmada-HA-workload-example1/step3/text.md
+++ b/karmada-HA-workload-example1/step3/text.md
@@ -1,3 +1,3 @@
-### create PropagationPolicy and deploy nginx to specific clusters
+### Create PropagationPolicy and deploy nginx to specific clusters
 
    RUN `kubectl --kubeconfig /etc/karmada/karmada-apiserver.config create -f ~/nginx/propagationPolicy.yaml`{{exec}}

--- a/karmada-HA-workload-example1/step3/text.md
+++ b/karmada-HA-workload-example1/step3/text.md
@@ -1,3 +1,3 @@
-### create propagationpolicy and deploy nginx to specific clusters
+### create PropagationPolicy and deploy nginx to specific clusters
 
    RUN `kubectl --kubeconfig /etc/karmada/karmada-apiserver.config create -f ~/nginx/propagationPolicy.yaml`{{exec}}

--- a/karmada-HA-workload-example2/finish.md
+++ b/karmada-HA-workload-example2/finish.md
@@ -1,3 +1,3 @@
 **Summary**
 
-In this scenario, we learned how deploy workloads across multiple clusters using PropagationPolicy with StaticWeight configuration to divide the nginx deployment.
+In this scenario, we learned how to deploy workloads across multiple clusters using PropagationPolicy with StaticWeight configuration to divide the nginx deployment.

--- a/karmada-HA-workload-example2/foreground.sh
+++ b/karmada-HA-workload-example2/foreground.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 # variable define
-kind_version=v0.17.0
+kind_version=v0.26.0
 host_cluster_ip=172.30.1.2 #host node where Karmada is located
 member_cluster_ip=172.30.2.2
 local_ip=127.0.0.1
@@ -74,14 +74,14 @@ function nginxDeployment() {
             app: nginx
         spec:
           containers:
-          - image: nginx
+          - image: nginx:1.27-alpine
             name: nginx
 EOF
 }
 
 function propagationPolicy() {
     cat << EOF > propagationPolicy.yaml
-    apiVersion: policy.karmada.io/v1alpha1
+    apiVersion: policy.karmada.io/v1beta1
     kind: PropagationPolicy
     metadata:
       name: nginx-propagation
@@ -143,7 +143,7 @@ ssh -o StrictHostKeyChecking=no root@${member_cluster_ip} "bash ~/createCluster.
 sleep 90
 
 # install karmadactl
-curl -s https://raw.githubusercontent.com/karmada-io/karmada/master/hack/install-cli.sh | sudo bash
+curl -s https://raw.githubusercontent.com/karmada-io/karmada/v1.12.0/hack/install-cli.sh | sudo bash
 
 # init karmada
 karmadactl init

--- a/karmada-HA-workload-example2/index.json
+++ b/karmada-HA-workload-example2/index.json
@@ -8,7 +8,7 @@
       },
       "steps": [
         {
-          "title": "Check member cluster has joined",
+          "title": "Check member cluster has been joined",
           "text": "step1/text.md",
           "verify": "step1/verify.sh"
         },
@@ -18,7 +18,7 @@
           "verify": "step2/verify.sh"
         },
         {
-          "title": "Create propagationPolicy and deploy deployment",
+          "title": "Create propagationPolicy and deploy workload",
           "text": "step3/text.md",
           "verify": "step3/verify.sh"
         },

--- a/karmada-HA-workload-example2/step3/text.md
+++ b/karmada-HA-workload-example2/step3/text.md
@@ -1,3 +1,3 @@
-### create PropagationPolicy and deploy nginx to specific clusters
+### Create PropagationPolicy and deploy nginx to specific clusters
 
    RUN `kubectl --kubeconfig /etc/karmada/karmada-apiserver.config create -f ~/nginx/propagationPolicy.yaml`{{exec}}

--- a/karmada-HA-workload-example2/step3/text.md
+++ b/karmada-HA-workload-example2/step3/text.md
@@ -1,3 +1,3 @@
-### create propagationpolicy and deploy nginx to specific clusters
+### create PropagationPolicy and deploy nginx to specific clusters
 
    RUN `kubectl --kubeconfig /etc/karmada/karmada-apiserver.config create -f ~/nginx/propagationPolicy.yaml`{{exec}}


### PR DESCRIPTION
## Related issue
Closes #18 
## What changed and why

### 1. `kind` version bumped from v0.17.0 to v0.26.0
`kind_version=v0.17.0` was hardcoded in all 4 `foreground.sh` files. This 
version is from early 2023 and the node images it tries to pull from Docker 
Hub may no longer be available, causing member cluster creation to fail 
silently on scenario load.

**Files changed:** all 4 `foreground.sh` files, line 8

### 2. karmadactl install script pinned to v1.12.0
The install script was fetched from the `master` branch, meaning every 
learner could get a different karmadactl version depending on when they ran 
the scenario. Pinning to `v1.12.0` ensures consistent behaviour across all 
runs.

**Files changed:** `karmada-HA-workload-example1/foreground.sh`, 
`karmada-HA-workload-example2/foreground.sh`, 
`karmada-Failover-example/foreground.sh`

### 3. nginx image pinned to nginx:1.27-alpine
All scenarios used `image: nginx` with no tag, resolving to `latest` at pull 
time. Pinning to `nginx:1.27-alpine` prevents scenarios from breaking silently 
if a future nginx release introduces a breaking change. Alpine also reduces 
pull time inside Killercoda.

**Files changed:** `nginxDeployment()` function in `karmada-HA-workload-example1/foreground.sh`, 
`karmada-HA-workload-example2/foreground.sh`, 
`karmada-Failover-example/foreground.sh`

### 4. PropagationPolicy apiVersion updated from v1alpha1 to v1beta1
All PropagationPolicy YAML definitions used `policy.karmada.io/v1alpha1`. 
This is an unstable API that can change between releases. `v1beta1` has been 
the stable recommended version since Karmada v1.7 and is what the official 
docs now reference.

**Files changed:** `propagationPolicy()` function in `karmada-HA-workload-example1/foreground.sh`, 
`karmada-HA-workload-example2/foreground.sh`, 
`karmada-Failover-example/foreground.sh`