### PR TITLE
feat: add Killercoda scenario for Workload Affinity and Anti-Affinity scheduling (v1.17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ You can enjoy tutorial experience about Karmada with following platforms.
 ## Contribution
 
 If you know of any excellent online interactive platforms, we welcome any pull requests to adapt the scenarios to the new platform.
+* Try [Workload Affinity and Anti-Affinity Scheduling with Karmada](https://killercoda.com/karmada/scenario/karmada-workload-affinity-example).

--- a/karmada-workload-affinity-example/background.sh
+++ b/karmada-workload-affinity-example/background.sh
@@ -85,8 +85,9 @@ if kind get clusters 2>/dev/null | grep -q "^karmada-host$"; then
       -p='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--feature-gates=WorkloadAffinity=true"}]'
 
     kubectl --kubeconfig "$HOST_KUBECONFIG" \
+      kubectl --kubeconfig "$HOST_KUBECONFIG" \
       -n karmada-system rollout status deployment/karmada-scheduler \
-      --timeout=120s || true
+      --timeout=300s
   fi
 fi
 

--- a/karmada-workload-affinity-example/background.sh
+++ b/karmada-workload-affinity-example/background.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Runs silently while the user reads the intro.
+# Installs Karmada v1.17 with three member clusters and enables the
+# WorkloadAffinity feature gate in the karmada-scheduler.
+set -euo pipefail
+
+KARMADA_ROOT=/root/karmada
+KARMADA_APISERVER_KUBECONFIG=/etc/karmada/karmada-apiserver.config
+HOST_KUBECONFIG=/root/.kube/karmada-host.config
+
+log() { echo "[background] $*"; }
+
+# ── Idempotency guard ────────────────────────────────────────────────────────
+if command -v kubectl &>/dev/null \
+   && [ -f "$KARMADA_APISERVER_KUBECONFIG" ] \
+   && kubectl --kubeconfig "$KARMADA_APISERVER_KUBECONFIG" get clusters &>/dev/null 2>&1; then
+  log "Karmada already set up — skipping."
+  exit 0
+fi
+
+# ── System dependencies ──────────────────────────────────────────────────────
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y \
+  curl git wget conntrack socat \
+  apt-transport-https ca-certificates gnupg lsb-release
+
+# ── Docker ───────────────────────────────────────────────────────────────────
+if ! command -v docker &>/dev/null; then
+  curl -fsSL https://get.docker.com | sh
+fi
+systemctl start docker 2>/dev/null || true
+
+# ── Go 1.21 ──────────────────────────────────────────────────────────────────
+GO_VERSION=1.21.5
+if ! command -v go &>/dev/null; then
+  wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O /tmp/go.tar.gz
+  tar -C /usr/local -xzf /tmp/go.tar.gz
+  rm /tmp/go.tar.gz
+fi
+export GOROOT=/usr/local/go
+export GOPATH=/root/go
+export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+
+# ── kubectl ──────────────────────────────────────────────────────────────────
+if ! command -v kubectl &>/dev/null; then
+  KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+  curl -fsSLo /usr/local/bin/kubectl \
+    "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+  chmod +x /usr/local/bin/kubectl
+fi
+
+# ── kind ─────────────────────────────────────────────────────────────────────
+if ! command -v kind &>/dev/null; then
+  curl -fsSLo /usr/local/bin/kind \
+    "https://kind.sigs.k8s.io/dl/v0.22.0/kind-linux-amd64"
+  chmod +x /usr/local/bin/kind
+fi
+
+# ── Clone Karmada v1.17.0 ────────────────────────────────────────────────────
+if [ ! -d "$KARMADA_ROOT/.git" ]; then
+  git clone --depth 1 --branch v1.17.0 \
+    https://github.com/karmada-io/karmada.git "$KARMADA_ROOT"
+fi
+
+# ── Run local-up-karmada.sh ──────────────────────────────────────────────────
+cd "$KARMADA_ROOT"
+hack/local-up-karmada.sh
+
+# ── Enable WorkloadAffinity feature gate in karmada-scheduler ────────────────
+# local-up-karmada.sh creates a kind cluster called "karmada-host" where the
+# Karmada control-plane pods live.
+if kind get clusters 2>/dev/null | grep -q "^karmada-host$"; then
+  kind get kubeconfig --name karmada-host > "$HOST_KUBECONFIG" 2>/dev/null
+
+  # Only patch if the flag is not already present
+  EXISTING=$(kubectl --kubeconfig "$HOST_KUBECONFIG" \
+    -n karmada-system get deployment karmada-scheduler \
+    -o jsonpath='{.spec.template.spec.containers[0].command}' 2>/dev/null || echo "")
+
+  if ! echo "$EXISTING" | grep -q "WorkloadAffinity"; then
+    kubectl --kubeconfig "$HOST_KUBECONFIG" \
+      -n karmada-system patch deployment karmada-scheduler \
+      --type=json \
+      -p='[{"op":"add","path":"/spec/template/spec/containers/0/command/-","value":"--feature-gates=WorkloadAffinity=true"}]'
+
+    kubectl --kubeconfig "$HOST_KUBECONFIG" \
+      -n karmada-system rollout status deployment/karmada-scheduler \
+      --timeout=120s || true
+  fi
+fi
+
+log "Setup complete. WorkloadAffinity feature gate is active."

--- a/karmada-workload-affinity-example/finish.md
+++ b/karmada-workload-affinity-example/finish.md
@@ -1,0 +1,54 @@
+# Congratulations!
+
+You have successfully completed the **Workload Affinity and Anti-Affinity Scheduling**
+scenario for Karmada v1.17.
+
+## What You Accomplished
+
+| Step | What you did | Outcome |
+|------|-------------|---------|
+| 1 | Verified all three member clusters were `Ready` | Healthy multi-cluster foundation |
+| 2 | Deployed `frontend` + `backend` with **affinity** (`groupByLabelKey: app`) | Both landed on the **same** cluster |
+| 3 | Deployed `service-a` + `service-b` with **anti-affinity** (`groupByLabelKey: ha-group`) | Each landed on a **different** cluster |
+| 4 | Inspected `ResourceBinding` objects | Confirmed all scheduling decisions |
+
+## Key Takeaways
+
+**Workload Affinity** is useful when:
+- Services communicate frequently and cross-cluster traffic is expensive.
+- You want all components of a micro-service tier to share the same failure domain.
+
+**Workload Anti-Affinity** is useful when:
+- You run active-active replicas and need them spread across failure domains.
+- Regulations require geographic or infrastructure separation between instances.
+
+**The `groupByLabelKey` field** is the glue: the scheduler groups every `PropagationPolicy`
+that references the same key and treats them as a single scheduling unit for affinity /
+anti-affinity decisions.
+
+## Cleaning Up
+
+To remove everything created during this scenario:
+
+```bash
+KUBECONFIG=/etc/karmada/karmada-apiserver.config
+
+# Delete workloads and policies from step 2
+kubectl --kubeconfig $KUBECONFIG delete deployment frontend backend -n default
+kubectl --kubeconfig $KUBECONFIG delete propagationpolicy frontend-policy backend-policy -n default
+
+# Delete workloads and policies from step 3
+kubectl --kubeconfig $KUBECONFIG delete deployment service-a service-b -n default
+kubectl --kubeconfig $KUBECONFIG delete propagationpolicy service-a-policy service-b-policy -n default
+```
+
+## What to Explore Next
+
+- **SpreadConstraint** — combine affinity rules with `maxClusters` / `minClusters` for
+  fine-grained spread control.
+- **PropagationPolicy weights** — influence which cluster a group lands on when multiple
+  clusters are eligible.
+- **ClusterOverridePolicy** — apply cluster-specific patches on top of affinity-placed
+  workloads.
+
+For more details see the [Karmada documentation](https://karmada.io/docs/).

--- a/karmada-workload-affinity-example/index.json
+++ b/karmada-workload-affinity-example/index.json
@@ -1,0 +1,39 @@
+{
+  "title": "Workload Affinity and Anti-Affinity Scheduling in Karmada",
+  "description": "Learn how to co-locate or spread workloads across member clusters using the WorkloadAffinity feature introduced in Karmada v1.17.",
+  "details": {
+    "steps": [
+      {
+        "title": "Verify the Karmada Environment",
+        "text": "step1.md",
+        "verify": "step1/verify.sh"
+      },
+      {
+        "title": "Deploy Workloads with Workload Affinity",
+        "text": "step2.md",
+        "verify": "step2/verify.sh"
+      },
+      {
+        "title": "Deploy Workloads with Workload Anti-Affinity",
+        "text": "step3.md",
+        "verify": "step3/verify.sh"
+      },
+      {
+        "title": "Observe and Inspect Scheduling Decisions",
+        "text": "step4.md",
+        "verify": "step4/verify.sh"
+      }
+    ],
+    "intro": {
+      "text": "intro.md",
+      "background": "background.sh"
+    },
+    "finish": {
+      "text": "finish.md"
+    }
+  },
+  "backend": {
+    "imageid": "ubuntu:2004"
+  },
+  "time": 30
+}

--- a/karmada-workload-affinity-example/intro.md
+++ b/karmada-workload-affinity-example/intro.md
@@ -1,0 +1,46 @@
+# Workload Affinity and Anti-Affinity Scheduling in Karmada
+
+Karmada v1.17 introduces **Workload Affinity** and **Workload Anti-Affinity** scheduling — a
+mechanism for controlling how groups of workloads are co-located or spread across your
+multi-cluster fleet based on shared labels.
+
+## Why This Matters
+
+In a multi-cluster setup you often face two opposing requirements:
+
+| Goal | Mechanism |
+|------|-----------|
+| Services that talk to each other should land on the **same** cluster (low latency, no cross-cluster traffic) | **Workload Affinity** |
+| Redundant services should land on **different** clusters (high availability, fault isolation) | **Workload Anti-Affinity** |
+
+Before v1.17 you had to hard-code `clusterNames` in every policy to achieve this. Now the
+scheduler handles it automatically by grouping workloads on a shared label key.
+
+## How It Works
+
+Rules live inside a `PropagationPolicy` under `.spec.placement.workloadAffinity`:
+
+```yaml
+placement:
+  workloadAffinity:
+    affinity:              # OR antiAffinity
+      groupByLabelKey: app # label key used to group workloads
+```
+
+The scheduler finds all workloads whose `PropagationPolicy` references the same
+`groupByLabelKey` and:
+- **affinity** — schedules them all on the cluster already chosen by the group.
+- **antiAffinity** — spreads them so no two workloads in the group share a cluster.
+
+## What You Will Do
+
+1. Verify that all three member clusters are healthy.
+2. Deploy `frontend` + `backend` with **affinity** and confirm they land on the same cluster.
+3. Deploy `service-a` + `service-b` with **anti-affinity** and confirm they land on different clusters.
+4. Inspect the `ResourceBinding` objects to see exactly which cluster each workload was assigned to.
+
+## Environment
+
+The background setup script is now installing Karmada (this takes a few minutes). Once the
+terminal is unlocked, all three member clusters — `member1`, `member2`, and `member3` — will
+be joined and the `WorkloadAffinity` feature gate will be active.

--- a/karmada-workload-affinity-example/step1.md
+++ b/karmada-workload-affinity-example/step1.md
@@ -1,0 +1,35 @@
+# Step 1 — Verify the Karmada Environment
+
+Before deploying any workloads you need to confirm that all three member clusters are
+registered with the Karmada control plane and in a `Ready` state.
+
+## Task
+
+List all clusters known to Karmada:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config get clusters
+```
+
+Expected output (all three clusters must show `Ready = True`):
+
+```
+NAME      VERSION   MODE   READY   AGE
+member1   v1.xx.x   Push   True    Xm
+member2   v1.xx.x   Push   True    Xm
+member3   v1.xx.x   Push   True    Xm
+```
+
+If you want to inspect a specific cluster in detail:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe cluster member1
+```
+
+Look for the `Conditions` section and confirm `Ready` is `True`.
+
+## Verify
+
+The check script queries each cluster object and verifies its `Ready` condition. Click
+**Check** once all three clusters appear as `Ready`.

--- a/karmada-workload-affinity-example/step1/verify.sh
+++ b/karmada-workload-affinity-example/step1/verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECONFIG=/etc/karmada/karmada-apiserver.config
+
+for cluster in member1 member2 member3; do
+  status=$(kubectl --kubeconfig "$KUBECONFIG" \
+    get cluster "$cluster" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+
+  if [ "$status" != "True" ]; then
+    echo "FAIL: cluster '$cluster' is not Ready (got: '${status:-<not found>}')"
+    exit 1
+  fi
+done
+
+echo "PASS: member1, member2, and member3 are all Ready."
+exit 0

--- a/karmada-workload-affinity-example/step2.md
+++ b/karmada-workload-affinity-example/step2.md
@@ -1,0 +1,135 @@
+# Step 2 — Deploy Workloads with Workload Affinity
+
+In this step you will deploy two Deployments — `frontend` and `backend` — that both carry
+the label `app: shop`. By setting `workloadAffinity.affinity.groupByLabelKey: app` in each
+`PropagationPolicy`, the Karmada scheduler will guarantee that **both workloads land on the
+same member cluster**.
+
+## Task
+
+### 2a — Create the Deployments
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: default
+  labels:
+    app: shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shop
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        app: shop
+        tier: frontend
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable-alpine
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  namespace: default
+  labels:
+    app: shop
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shop
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: shop
+        tier: backend
+    spec:
+      containers:
+        - name: httpbin
+          image: kennethreitz/httpbin
+          ports:
+            - containerPort: 80
+EOF
+```
+
+### 2b — Create the PropagationPolicies with Workload Affinity
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config apply -f - <<'EOF'
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: frontend-policy
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: frontend
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    workloadAffinity:
+      affinity:
+        groupByLabelKey: app
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: backend-policy
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: backend
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    workloadAffinity:
+      affinity:
+        groupByLabelKey: app
+EOF
+```
+
+### 2c — Watch the ResourceBindings
+
+The Karmada scheduler creates a `ResourceBinding` for each propagated resource. Watch them
+appear and check that both show the **same** cluster under `SCHEDULED CLUSTER`:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  get resourcebindings -n default -w
+```
+
+Press `Ctrl+C` once both `frontend-deployment` and `backend-deployment` appear.
+
+You can also inspect a binding in detail:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding frontend-deployment -n default
+```
+
+## Verify
+
+The check script waits up to 120 seconds for both `ResourceBinding` objects to appear and
+confirms that `.spec.clusters[0].name` is identical for `frontend-deployment` and
+`backend-deployment`. Click **Check** once you have applied all the manifests above.

--- a/karmada-workload-affinity-example/step2/verify.sh
+++ b/karmada-workload-affinity-example/step2/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECONFIG=/etc/karmada/karmada-apiserver.config
+TIMEOUT=120
+INTERVAL=5
+elapsed=0
+
+echo "Waiting for frontend-deployment and backend-deployment ResourceBindings to be scheduled..."
+
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  frontend_cluster=$(kubectl --kubeconfig "$KUBECONFIG" \
+    get resourcebinding frontend-deployment -n default \
+    -o jsonpath='{.spec.clusters[0].name}' 2>/dev/null || echo "")
+
+  backend_cluster=$(kubectl --kubeconfig "$KUBECONFIG" \
+    get resourcebinding backend-deployment -n default \
+    -o jsonpath='{.spec.clusters[0].name}' 2>/dev/null || echo "")
+
+  if [ -n "$frontend_cluster" ] && [ -n "$backend_cluster" ]; then
+    if [ "$frontend_cluster" = "$backend_cluster" ]; then
+      echo "PASS: frontend and backend are both scheduled on cluster '$frontend_cluster'."
+      exit 0
+    else
+      echo "FAIL: workload affinity violated — frontend is on '$frontend_cluster' but backend is on '$backend_cluster'."
+      exit 1
+    fi
+  fi
+
+  echo "  ResourceBindings not yet scheduled (${elapsed}s elapsed). Retrying in ${INTERVAL}s..."
+  sleep "$INTERVAL"
+  elapsed=$((elapsed + INTERVAL))
+done
+
+echo "FAIL: timed out after ${TIMEOUT}s waiting for ResourceBindings to be scheduled."
+exit 1

--- a/karmada-workload-affinity-example/step3.md
+++ b/karmada-workload-affinity-example/step3.md
@@ -1,0 +1,136 @@
+# Step 3 — Deploy Workloads with Workload Anti-Affinity
+
+Now you will deploy two Deployments — `service-a` and `service-b` — that both carry the
+label `ha-group: my-app`. By setting `workloadAffinity.antiAffinity.groupByLabelKey: ha-group`
+in each `PropagationPolicy`, the Karmada scheduler will guarantee that **the two workloads
+land on different member clusters**, improving availability.
+
+## Task
+
+### 3a — Create the Deployments
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-a
+  namespace: default
+  labels:
+    ha-group: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ha-group: my-app
+      component: service-a
+  template:
+    metadata:
+      labels:
+        ha-group: my-app
+        component: service-a
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable-alpine
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: service-b
+  namespace: default
+  labels:
+    ha-group: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      ha-group: my-app
+      component: service-b
+  template:
+    metadata:
+      labels:
+        ha-group: my-app
+        component: service-b
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable-alpine
+          ports:
+            - containerPort: 80
+EOF
+```
+
+### 3b — Create the PropagationPolicies with Workload Anti-Affinity
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config apply -f - <<'EOF'
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: service-a-policy
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: service-a
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    workloadAffinity:
+      antiAffinity:
+        groupByLabelKey: ha-group
+---
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: service-b-policy
+  namespace: default
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: service-b
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+        - member3
+    workloadAffinity:
+      antiAffinity:
+        groupByLabelKey: ha-group
+EOF
+```
+
+### 3c — Watch the ResourceBindings
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  get resourcebindings -n default -w
+```
+
+Press `Ctrl+C` once `service-a-deployment` and `service-b-deployment` appear. Notice that
+the `SCHEDULED CLUSTER` column shows **different** clusters for the two services.
+
+You can also confirm by describing each binding:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding service-a-deployment -n default
+
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding service-b-deployment -n default
+```
+
+## Verify
+
+The check script waits up to 120 seconds for both `ResourceBinding` objects to appear and
+confirms that `.spec.clusters[0].name` is **different** for `service-a-deployment` and
+`service-b-deployment`. Click **Check** once you have applied all the manifests above.

--- a/karmada-workload-affinity-example/step3/verify.sh
+++ b/karmada-workload-affinity-example/step3/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECONFIG=/etc/karmada/karmada-apiserver.config
+TIMEOUT=120
+INTERVAL=5
+elapsed=0
+
+echo "Waiting for service-a-deployment and service-b-deployment ResourceBindings to be scheduled..."
+
+while [ "$elapsed" -lt "$TIMEOUT" ]; do
+  servicea_cluster=$(kubectl --kubeconfig "$KUBECONFIG" \
+    get resourcebinding service-a-deployment -n default \
+    -o jsonpath='{.spec.clusters[0].name}' 2>/dev/null || echo "")
+
+  serviceb_cluster=$(kubectl --kubeconfig "$KUBECONFIG" \
+    get resourcebinding service-b-deployment -n default \
+    -o jsonpath='{.spec.clusters[0].name}' 2>/dev/null || echo "")
+
+  if [ -n "$servicea_cluster" ] && [ -n "$serviceb_cluster" ]; then
+    if [ "$servicea_cluster" != "$serviceb_cluster" ]; then
+      echo "PASS: workload anti-affinity enforced — service-a is on '$servicea_cluster', service-b is on '$serviceb_cluster'."
+      exit 0
+    else
+      echo "FAIL: workload anti-affinity violated — both service-a and service-b are on '$servicea_cluster'."
+      exit 1
+    fi
+  fi
+
+  echo "  ResourceBindings not yet scheduled (${elapsed}s elapsed). Retrying in ${INTERVAL}s..."
+  sleep "$INTERVAL"
+  elapsed=$((elapsed + INTERVAL))
+done
+
+echo "FAIL: timed out after ${TIMEOUT}s waiting for ResourceBindings to be scheduled."
+exit 1

--- a/karmada-workload-affinity-example/step4.md
+++ b/karmada-workload-affinity-example/step4.md
@@ -1,0 +1,73 @@
+# Step 4 — Observe and Inspect the Scheduling Decisions
+
+Now that both sets of workloads are running you can use `kubectl` to inspect exactly what the
+Karmada scheduler decided and understand how the `ResourceBinding` objects encode the
+placement.
+
+## Task
+
+### 4a — List all ResourceBindings across all namespaces
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  get resourcebindings -A
+```
+
+You should see four bindings:
+
+| NAME | SCHEDULED CLUSTER |
+|------|-------------------|
+| `frontend-deployment` | e.g. `member2` |
+| `backend-deployment`  | e.g. `member2` ← same as frontend |
+| `service-a-deployment` | e.g. `member1` |
+| `service-b-deployment` | e.g. `member3` ← different from service-a |
+
+### 4b — Compare the affinity group
+
+Describe the `frontend-deployment` and `backend-deployment` bindings side-by-side and note
+that both `.spec.clusters[0].name` values are identical:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding frontend-deployment -n default
+```
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding backend-deployment -n default
+```
+
+### 4c — Compare the anti-affinity group
+
+Describe the `service-a-deployment` and `service-b-deployment` bindings and note that
+`.spec.clusters[0].name` values are **different**:
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding service-a-deployment -n default
+```
+
+```bash
+kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+  describe resourcebinding service-b-deployment -n default
+```
+
+### 4d — Print a quick summary using jsonpath
+
+Use `jsonpath` to print just the cluster assignments in one command:
+
+```bash
+for rb in frontend-deployment backend-deployment service-a-deployment service-b-deployment; do
+  cluster=$(kubectl --kubeconfig /etc/karmada/karmada-apiserver.config \
+    get resourcebinding "$rb" -n default \
+    -o jsonpath='{.spec.clusters[0].name}')
+  echo "$rb  →  $cluster"
+done
+```
+
+## Verify
+
+The check script confirms that all four `ResourceBinding` objects exist and have a non-empty
+cluster assignment, and re-verifies both the affinity constraint (frontend == backend) and
+the anti-affinity constraint (service-a != service-b). Click **Check** once you have
+explored the bindings above.

--- a/karmada-workload-affinity-example/step4/verify.sh
+++ b/karmada-workload-affinity-example/step4/verify.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KUBECONFIG=/etc/karmada/karmada-apiserver.config
+FAILED=0
+
+get_cluster() {
+  kubectl --kubeconfig "$KUBECONFIG" \
+    get resourcebinding "$1" -n default \
+    -o jsonpath='{.spec.clusters[0].name}' 2>/dev/null || echo ""
+}
+
+# ── Check all four ResourceBindings exist and are bound ──────────────────────
+for rb in frontend-deployment backend-deployment service-a-deployment service-b-deployment; do
+  cluster=$(get_cluster "$rb")
+  if [ -z "$cluster" ]; then
+    echo "FAIL: ResourceBinding '$rb' is missing or has no cluster assignment."
+    FAILED=1
+  else
+    echo "OK:   $rb  →  $cluster"
+  fi
+done
+
+[ "$FAILED" -eq 1 ] && exit 1
+
+# ── Re-verify affinity constraint: frontend == backend ───────────────────────
+frontend_cluster=$(get_cluster frontend-deployment)
+backend_cluster=$(get_cluster backend-deployment)
+
+if [ "$frontend_cluster" != "$backend_cluster" ]; then
+  echo "FAIL: affinity constraint violated — frontend is on '$frontend_cluster' but backend is on '$backend_cluster'."
+  exit 1
+fi
+echo "OK:   affinity satisfied  — frontend and backend are both on '$frontend_cluster'."
+
+# ── Re-verify anti-affinity constraint: service-a != service-b ───────────────
+servicea_cluster=$(get_cluster service-a-deployment)
+serviceb_cluster=$(get_cluster service-b-deployment)
+
+if [ "$servicea_cluster" = "$serviceb_cluster" ]; then
+  echo "FAIL: anti-affinity constraint violated — service-a and service-b are both on '$servicea_cluster'."
+  exit 1
+fi
+echo "OK:   anti-affinity satisfied — service-a is on '$servicea_cluster', service-b is on '$serviceb_cluster'."
+
+echo ""
+echo "PASS: all four ResourceBindings are present and scheduling constraints are satisfied."
+exit 0


### PR DESCRIPTION
## What this PR does

Adds a new interactive Killercoda scenario for the Workload Affinity 
and Anti-Affinity Scheduling feature introduced in Karmada v1.17.

## Why

The playground currently has 4 scenarios but none covering the new 
WorkloadAffinity feature shipped in v1.17 (March 2026). This fills 
that gap and aligns with the LFX Mentorship 2026 Term 1 goal of 
adding tutorials for current Karmada features.

## Scenario structure

- Step 1: Verify the multi-cluster environment
- Step 2: Deploy workloads with Affinity (co-location)  
- Step 3: Deploy workloads with Anti-Affinity (spreading)
- Step 4: Inspect ResourceBinding scheduling decisions

Closes karmada-io/karmada#7498